### PR TITLE
Small improvement to errors.php

### DIFF
--- a/app/config/bootstrap/errors.php
+++ b/app/config/bootstrap/errors.php
@@ -17,7 +17,7 @@ ErrorHandler::apply('lithium\action\Dispatcher::run', array(), function($info, $
 	));
 
 	Media::render($response, compact('info', 'params'), array(
-		'library' => 'app',
+		'library' => true,
 		'controller' => '_errors',
 		'template' => 'development',
 		'layout' => 'error',


### PR DESCRIPTION
Today i installed `li3_bot`.
After installation, i visited http://host/bot and it threw a fatal error. The reason was, that it encountered an exception and tried to show the exception handling page. But it looked in the `li3_bot` library instead of the `app`. The corresponding view was not there and a fatal error was thrown.

With my newly accumulated knowledge about Lithium, i fixed the issue =)

before patch:

```
Media::render($response, compact('info', 'params'), array(
    'controller' => '_errors',
    'template' => 'development',
    'layout' => 'error',
    'request' => $params['request']
));
```

after patch:

```
Media::render($response, compact('info', 'params'), array(
    'library' => 'app',
    'controller' => '_errors',
    'template' => 'development',
    'layout' => 'error',
    'request' => $params['request']
));
```
