### PR TITLE
Fix an undefined variable error and a wrong parameters order for strpos

### DIFF
--- a/app/views/pages/home.html.php
+++ b/app/views/pages/home.html.php
@@ -35,10 +35,10 @@ $support = function($classes) {
 	return $result;
 };
 
-$compiled = function() {
+$compiled = function($flag) {
 	ob_start();
 	phpinfo(INFO_GENERAL);
-	return strpos($flag, ob_get_clean()) !== false;
+	return strpos(ob_get_clean(), $flag) !== false;
 };
 
 $checks = array(


### PR DESCRIPTION
Just spotted an `Undefined variable $flag` error on my errors logs.
Also, `strpos()` was wrong since we search for the given `$flag` in the phpinfo ob.
