### PR TITLE
Remove "url" from rewrite in app/webroot/.htaccess

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -3,5 +3,5 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !favicon.ico$
-    RewriteRule ^(.*)$ index.php?url=$1 [QSA,L]
+    RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
The url parameter should not be used in the rewrite, otherwise there is an extra url property in the request object.
