### PR TITLE
Promoting REQUEST_URI default usage for Apache.

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -3,5 +3,5 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !favicon.ico$
-    RewriteRule ^(.*)$ index.php?url=$1 [QSA,L]
+    RewriteRule ^ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
The `index.php?url=` way of working could lead to problems the `REQUEST_URI`'s one doesn't have. I'd like propose to use the later as default configuration instead of the naiver way.
- See: https://github.com/UnionOfRAD/lithium/issues/340
