### PR TITLE
Fix checking the current configuration setting of magic_quotes_gpc, for PHP 5.4

### DIFF
--- a/app/views/pages/home.html.php
+++ b/app/views/pages/home.html.php
@@ -65,7 +65,7 @@ $checks = array(
 		);
 	},
 	'magicQuotes' => function() use ($notify) {
-		if (get_magic_quotes_gpc() === 0) {
+		if (get_magic_quotes_gpc() == 0) {
 			return;
 		}
 		return $notify(


### PR DESCRIPTION
get_magic_quotes_gpc() returns 0 if magic_quotes_gpc is off, 1 otherwise. And always returns `false` as of PHP 5.4.0.

The strict equality produce a notification when running PHP5.4.
