### PR TITLE
Made the default page use the compiler fallback.

### DIFF
--- a/app/controllers/PagesController.php
+++ b/app/controllers/PagesController.php
@@ -26,8 +26,16 @@ namespace app\controllers;
 class PagesController extends \lithium\action\Controller {
 
 	public function view() {
-		$path = func_get_args() ?: array('home');
-		return $this->render(array('template' => join('/', $path)));
+		$options = array();
+		$path = func_get_args();
+
+		if (!$path || $path === array('home')) {
+			$path = array('home');
+			$options['compiler'] = array('fallback' => true);
+		}
+
+		$options['template'] = join('/', $path);
+		return $this->render($options);
 	}
 }
 


### PR DESCRIPTION
See #17.

Two differences here:
1 - Squashed.
2 - Using `$path === array('home')` not `==` because thanks to PHP `array(true) == array('home')` yields true.
