### PR TITLE
Submodule url of lithium

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libraries/lithium"]
 	path = libraries/lithium
-	url = git://github.com/UnionOfRAD/lithium.git
+	url = https://github.com/UnionOfRAD/lithium.git


### PR DESCRIPTION
Changed submodule url of lithium repository due to using git:// fails on connections behind firewall (like my current and previous company).
