### PR TITLE
Fixing IIS rewrite error

### DIFF
--- a/app/web.config
+++ b/app/web.config
@@ -17,7 +17,7 @@
                     </conditions>
                     <action type="Rewrite" url="webroot/{R:1}" />
                 </rule>
-                <rule name="Lithium Redirect">
+                <rule name="Lithium Redirect from App">
                     <match url="webroot/(.*)" />
                     <conditions>
                         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />


### PR DESCRIPTION
HTTP-error 500.52 - URL Rewrite Module Error in IIS 7 and 8: double use
of rule name is not allowed.

Tested on Windows 7 (IIS 7.5) and Windows 8 (IIS 8).
PHP installed with Microsoft Web Platform Installer.
