### PR TITLE
Fix Dispatcher filter that connects plugin asset routes.

### DIFF
--- a/app/config/bootstrap/media.php
+++ b/app/config/bootstrap/media.php
@@ -39,7 +39,8 @@ Collection::formats('lithium\net\http\Media');
 // use lithium\net\http\Media;
 //
 // Dispatcher::applyFilter('_callable', function($self, $params, $chain) {
-// 	list($library, $asset) = explode('/', $params['request']->url, 2) + array("", "");
+// 	$url = ltrim($params['request']->url, '/');
+// 	list($library, $asset) = explode('/', $url, 2) + array("", "");
 //
 // 	if ($asset && ($path = Media::webroot($library)) && file_exists($file = "{$path}/{$asset}")) {
 // 		return function() use ($file) {


### PR DESCRIPTION
If `$params['request']->url` has a leading slash, it should be trimmed before trying to explode the URL into the library and asset components.
