### PR TITLE
Adding rule for Apache to enable HTTP auth for CGI

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -1,5 +1,7 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    # Uncomment the line below, to enable HTTP authentication running PHP as a CGI.
+    # RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !favicon.ico$


### PR DESCRIPTION
This PR accompanies PR https://github.com/UnionOfRAD/lithium/pull/981 which adds support for HTTP under CGI. The rule is by default commented. In previous version I had written a more exhaustive docblock, but then thought it might be just to much having it there in the .htaccess file.
