### PR TITLE
Load routes under console environment too.

### DIFF
--- a/app/config/bootstrap/console.php
+++ b/app/config/bootstrap/console.php
@@ -8,14 +8,25 @@
 
 use lithium\console\Dispatcher;
 use lithium\core\Environment;
+use lithium\core\Libraries;
 
 /**
  * This filter sets the environment based on the current request. By default, `$request->env`, for
  * example in the command `li3 help --env=production`, is used to determine the environment.
  *
+ * Routes are also loaded, to facilitate URL generation from within the console environment.
+ *
  */
 Dispatcher::applyFilter('run', function($self, $params, $chain) {
 	Environment::set($params['request']);
+
+	foreach (array_reverse(Libraries::get()) as $name => $config) {
+		if ($name === 'lithium') {
+			continue;
+		}
+		$file = "{$config['path']}/config/routes.php";
+		file_exists($file) ? call_user_func(function () use ($file) { include $file; }) : null;
+	}
 	return $chain->next($self, $params, $chain);
 });
 


### PR DESCRIPTION
Prior to this update, application and plugin routes were not available from the console environment. The filter that loads the routes in bootstrap/action.php, applies to lithium\action\Dispatcher only. The filter logic for loading routes should also be applied to lithium\console\Dispatcher, so that Router related capabilities such as URL generation are possible from the console. 

One use case for this, is generating email notifications from the console as a CRON job, where application URLs need to be generated within the email.
