### PR TITLE
Merge Multibyte config with existing config

### DIFF
--- a/app/config/bootstrap/g11n.php
+++ b/app/config/bootstrap/g11n.php
@@ -127,7 +127,7 @@ Multibyte::config(array(
 //	'default' => array('adapter' => 'Intl'),
 	'default' => array('adapter' => 'Mbstring'),
 //	'default' => array('adapter' => 'Iconv')
-));
+) + Multibyte::config());
 
 /**
  * Transliteration


### PR DESCRIPTION
Allows for interoperability with libraries such as li3_quality that
define their own Multibyte configurations before g11n app bootstrap
begins.
