### PR TITLE
Don't require connections in config

### DIFF
--- a/app/config/bootstrap.php
+++ b/app/config/bootstrap.php
@@ -54,7 +54,7 @@ require __DIR__ . '/bootstrap/cache.php';
 /**
  * Include this file if your application uses one or more database connections.
  */
-require __DIR__ . '/bootstrap/connections.php';
+// require __DIR__ . '/bootstrap/connections.php';
 
 /**
  * This file contains configuration for session (and/or cookie) storage, and user or web service


### PR DESCRIPTION
The setup page instructs the user to un-comment the line requiring connections.php in the app config. However, this line was not commented.

![li3_setup](https://cloud.githubusercontent.com/assets/393346/7286233/ad2a4ae6-e94a-11e4-9e78-aee6e734933b.png)
