### PR TITLE
Added Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,14 @@
+localhost:2020
+
+gzip
+
+root app/webroot
+fastcgi / localhost:9000 php
+
+log app/resources/tmp/logs/access.log
+errors app/resources/tmp/logs/error.log
+
+rewrite / {
+	if {file} not favicon.ico
+	to {path} {path}/ /index.php?url={query}
+}


### PR DESCRIPTION
This enables caddy server to be used without additional configuration.

## usage

Clone the repository, cd into it and run `caddy`

##  requirements

You only need to have caddy installed and php-fpm running on port 9000.

see https://caddyserver.com/docs/caddyfile